### PR TITLE
Fix Signature Update happening before signature.always_valid/ready

### DIFF
--- a/amaranth/lib/stream.py
+++ b/amaranth/lib/stream.py
@@ -94,11 +94,12 @@ class Interface:
             raise TypeError(f"Signature of stream.Interface must be a stream.Signature, not "
                             f"{signature!r}")
         self._signature = signature
-        self.__dict__.update(signature.members.create(path=path, src_loc_at=1 + src_loc_at))
         if signature.always_valid:
             self.valid = Const(1)
         if signature.always_ready:
             self.ready = Const(1)
+        self.__dict__.update(signature.members.create(path=path, src_loc_at=1 + src_loc_at))
+        
 
     @property
     def signature(self):


### PR DESCRIPTION
fix: #4 

The problem with current stream.py's `Interface` is that update happens before self.valid and self.ready is set.

Previous:
```python
self._signature = signature
self.__dict__.update(signature.members.create(path=path, src_loc_at=1 + src_loc_at))
if signature.always_valid:
    self.valid = Const(1)
if signature.always_ready:
    self.ready = Const(1)
```

Current:

```python
self._signature = signature
if signature.always_valid:
    self.valid = Const(1)
if signature.always_ready:
    self.ready = Const(1)
self.__dict__.update(signature.members.create(path=path, src_loc_at=1 + src_loc_at))
```