### PR TITLE
Enum now gets shape=;view_class=; for signed/unsigned bits

### DIFF
--- a/amaranth/lib/enum.py
+++ b/amaranth/lib/enum.py
@@ -1,4 +1,6 @@
 import enum as py_enum
+import sys
+import types as py_types
 import warnings
 import operator
 
@@ -127,8 +129,8 @@ class EnumType(ShapeCastable, py_enum.EnumMeta):
             # replacement for `enum.Enum`.
             return Shape._cast_plain_enum(cls)
 
-    def __call__(cls, value, *args, **kwargs):
-        """Cast the value to this enum type.
+    def __call__(cls, value, *args, shape=None, view_class=None, **kwargs):
+        """Cast the value to this enum type, or create a new enum class (functional API).
 
         When given an integer constant, it returns the corresponding enum value, like a standard
         Python enumeration.
@@ -139,6 +141,10 @@ class EnumType(ShapeCastable, py_enum.EnumMeta):
         ``view_class`` (like :class:`IntEnum` or :class:`IntFlag`), a plain
         :class:`Value` is returned.
 
+        When used as a functional API (i.e. ``Enum('Color', ['RED', 'GREEN'])``) the ``shape=``
+        and ``view_class=`` keyword arguments are forwarded to the metaclass to create an enum
+        with an explicit shape, just like the ``class`` syntax.
+
         Returns
         -------
         instance of itself
@@ -147,6 +153,8 @@ class EnumType(ShapeCastable, py_enum.EnumMeta):
             For value-castables, as defined by the ``view_class`` keyword argument.
         :class:`Value`
             For value-castables, when a view class is not specified for this enum.
+        A new enum class
+            When used as the functional API.
         """
         if isinstance(value, (Value, ValueCastable)):
             value = Value.cast(value)
@@ -154,7 +162,73 @@ class EnumType(ShapeCastable, py_enum.EnumMeta):
                 return value
             else:
                 return cls._amaranth_view_class_(cls, value)
-        return super().__call__(value, *args, **kwargs)
+        if shape is None and view_class is None:
+            return super().__call__(value, *args, **kwargs)
+
+        # Functional API with shape and/or view_class. The stdlib's _create_ does not
+        # forward these to __new__, so we handle creation via types.new_class which
+        # properly passes keyword arguments through to EnumType.__new__.
+        if args:
+            names = args[0]
+        elif 'names' in kwargs:
+            names = kwargs.pop('names')
+        else:
+            raise TypeError(
+                "'shape' and 'view_class' can only be used with the functional API"
+            )
+
+        module = kwargs.pop('module', None)
+        qualname = kwargs.pop('qualname', None)
+        type_ = kwargs.pop('type', None)
+        start = kwargs.pop('start', 1)
+        boundary = kwargs.pop('boundary', None)
+
+        bases = (cls,) if type_ is None else (type_, cls)
+
+        if isinstance(names, str):
+            names = names.replace(',', ' ').split()
+        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str):
+            _, first_enum = cls._get_mixins_(value, bases)
+            processed = []
+            last_values = []
+            for count, name in enumerate(names):
+                v = first_enum._generate_next_value_(name, start, count, last_values[:])
+                last_values.append(v)
+                processed.append((name, v))
+            names = processed
+        if names is None:
+            names = ()
+
+        kwds = {}
+        if shape is not None:
+            kwds['shape'] = shape
+        if view_class is not None:
+            kwds['view_class'] = view_class
+        if boundary is not None:
+            kwds['boundary'] = boundary
+
+        if module is None:
+            try:
+                module = sys._getframemodulename(1)
+            except AttributeError:
+                try:
+                    module = sys._getframe(1).f_globals['__name__']
+                except (AttributeError, ValueError, KeyError):
+                    pass
+
+        processed_names = names
+        def exec_body(ns):
+            if module is not None:
+                ns['__module__'] = module
+            if qualname is not None:
+                ns['__qualname__'] = qualname
+            for item in processed_names:
+                if isinstance(item, str):
+                    ns[item] = processed_names[item]
+                else:
+                    ns[item[0]] = item[1]
+
+        return py_types.new_class(value, bases, kwds, exec_body)
 
     def const(cls, init):
         # Same considerations apply as above.

--- a/tests/test_lib_enum.py
+++ b/tests/test_lib_enum.py
@@ -132,6 +132,69 @@ class EnumTestCase(FHDLTestCase):
     def test_functional(self):
         Enum("FOO", ["BAR", "BAZ"])
 
+    def test_functional_with_shape(self):
+        EnumA = Enum("EnumA", ["X", "Y", "Z"], shape=unsigned(4))
+        self.assertIsInstance(EnumA, EnumType)
+        self.assertEqual(Shape.cast(EnumA), unsigned(4))
+        self.assertEqual([(m.name, m.value) for m in EnumA],
+                         [("X", 1), ("Y", 2), ("Z", 3)])
+
+    def test_functional_with_shape_str_names(self):
+        EnumA = Enum("EnumA", "A B C", shape=unsigned(4))
+        self.assertEqual(Shape.cast(EnumA), unsigned(4))
+        self.assertEqual([(m.name, m.value) for m in EnumA],
+                         [("A", 1), ("B", 2), ("C", 3)])
+
+    def test_functional_with_shape_tuple_pairs(self):
+        EnumA = Enum("EnumA", [("X", 10), ("Y", 20)], shape=unsigned(8))
+        self.assertEqual(Shape.cast(EnumA), unsigned(8))
+        self.assertEqual([(m.name, m.value) for m in EnumA],
+                         [("X", 10), ("Y", 20)])
+
+    def test_functional_with_shape_dict(self):
+        EnumA = Enum("EnumA", {"P": 5, "Q": 6}, shape=unsigned(4))
+        self.assertEqual(Shape.cast(EnumA), unsigned(4))
+        self.assertEqual([(m.name, m.value) for m in EnumA],
+                         [("P", 5), ("Q", 6)])
+
+    def test_functional_with_shape_start(self):
+        EnumA = Enum("EnumA", ["A", "B"], shape=unsigned(8), start=10)
+        self.assertEqual([(m.name, m.value) for m in EnumA],
+                         [("A", 10), ("B", 11)])
+
+    def test_functional_with_shape_keyword_names(self):
+        EnumA = Enum("EnumA", names=["A", "B"], shape=unsigned(4))
+        self.assertEqual(Shape.cast(EnumA), unsigned(4))
+        self.assertEqual([(m.name, m.value) for m in EnumA],
+                         [("A", 1), ("B", 2)])
+
+    def test_functional_with_shape_empty(self):
+        EnumA = Enum("EnumA", [], shape=unsigned(4))
+        self.assertIsInstance(EnumA, EnumType)
+        self.assertEqual(Shape.cast(EnumA), unsigned(4))
+        self.assertEqual(list(EnumA), [])
+
+    def test_functional_with_shape_signal(self):
+        EnumA = Enum("EnumA", [("A", 0), ("B", 1)], shape=unsigned(2))
+        a = Signal(EnumA)
+        self.assertIsInstance(a, EnumView)
+        self.assertIs(a.shape(), EnumA)
+
+    def test_functional_with_shape_view_class(self):
+        EnumA = Enum("EnumA", [("A", 0)], shape=unsigned(2), view_class=EnumView)
+        self.assertIs(EnumA._amaranth_view_class_, EnumView)
+
+    def test_functional_with_shape_truncation_warning(self):
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^Value 256 of enumeration member 'A' will be truncated to "
+                r"the enumeration shape unsigned\(4\)$"):
+            Enum("EnumA", [("A", 256)], shape=unsigned(4))
+
+    def test_functional_shape_without_names_wrong(self):
+        with self.assertRaisesRegex(TypeError,
+                r"'shape' and 'view_class' can only be used with the functional API"):
+            Enum(1, shape=unsigned(4))
+
     def test_int_enum(self):
         class EnumA(IntEnum, shape=signed(4)):
             A = 0


### PR DESCRIPTION
fix #6 

Currently EnumType.__call__ does not accept shape as parameters.
This makes Enum more to Python's default Enum.
By allowing getting shape to allocate signed/unsigned bits,  users can clearly define the bits for members.

