### PR TITLE
Add github workflows to have stable channel for docs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -193,6 +193,15 @@ jobs:
           branch: main
           folder: docs/
           target-folder: docs/amaranth/${{ github.ref_name }}/
+      - name: Publish stable documentation
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, 'dev') }}
+        uses: JamesIves/github-pages-deploy-action@releases/v4
+        with:
+          repository-name: amaranth-lang/amaranth-lang.github.io
+          ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
+          branch: main
+          folder: docs/
+          target-folder: docs/amaranth/stable/
       - name: Generate list of versions
         if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, 'dev')) }}
         run: |


### PR DESCRIPTION
fix #3 

Now we have https://amaranth-lang.org/docs/amaranth/stable/, which is essentially same as
https://amaranth-lang.org/docs/amaranth/<version>